### PR TITLE
Changes to allow NS records and glue to be provided

### DIFF
--- a/etc/polaris-lb.yaml.dist
+++ b/etc/polaris-lb.yaml.dist
@@ -43,4 +43,12 @@ globalnames:
         pool: ns-example
         ttl: 3600
         nsrecord: true
+    ns1.example.com:
+        pool: ns-example
+        ttl: 3600
+        nsrecord: false
+    ns2.example.com:
+        pool: ns-example
+        ttl: 3600
+        nsrecord: false
 

--- a/etc/polaris-lb.yaml.dist
+++ b/etc/polaris-lb.yaml.dist
@@ -2,6 +2,19 @@
 # Example configuration
 #
 pools:
+    ns-example:
+        monitor: tcp
+        monitor_params:
+            port: 53
+        lb_method: wrr
+        fallback: refuse
+        members:
+        - ip: 10.20.30.40
+          name: ns1.example.com
+          weight: 1
+        - ip: 10.20.30.50
+          name: ns2.example.com
+          weight: 1
     www-example:
         monitor: http
         monitor_params:
@@ -25,4 +38,9 @@ globalnames:
     www.example.com:
         pool: www-example
         ttl: 1
+        nsrecord: false
+    example.com:
+        pool: ns-example
+        ttl: 3600
+        nsrecord: true
 

--- a/polaris_health/state/globalname.py
+++ b/polaris_health/state/globalname.py
@@ -73,9 +73,14 @@ class GlobalName:
                        .format(name))
             LOG.error(log_msg)
             raise Error(log_msg)
- 
-        return cls(name=name, pool_name=obj['pool'], ttl=obj['ttl'], nsrecord=obj['nsrecord'])
 
+        if 'nsrecord' not in obj:
+            nsrecord_val=False
+        else:
+            nsrecord_val=obj['nsrecord']
+
+        return cls(name=name, pool_name=obj['pool'], ttl=obj['ttl'], nsrecord=nsrecord_val)
+ 
     def to_dist_dict(self):
         """Return a dict representation of the GlobalName required by 
         Polaris PDNS to perform distribution.

--- a/polaris_health/state/globalname.py
+++ b/polaris_health/state/globalname.py
@@ -17,7 +17,7 @@ class GlobalName:
 
     """Load-balnced DNS name"""
 
-    def __init__(self, name, pool_name, ttl):
+    def __init__(self, name, pool_name, ttl, nsrecord):
         """
         args:
             name: str, DNS name to be load-balanced
@@ -51,6 +51,8 @@ class GlobalName:
             LOG.error(log_msg)
             raise Error(log_msg)
 
+        self.nsrecord = nsrecord
+
     @classmethod
     def from_config_dict(cls, name, obj):
         """Build a GlobalName object from a config dict.
@@ -72,7 +74,7 @@ class GlobalName:
             LOG.error(log_msg)
             raise Error(log_msg)
  
-        return cls(name=name, pool_name=obj['pool'], ttl=obj['ttl'])
+        return cls(name=name, pool_name=obj['pool'], ttl=obj['ttl'], nsrecord=obj['nsrecord'])
 
     def to_dist_dict(self):
         """Return a dict representation of the GlobalName required by 
@@ -88,6 +90,7 @@ class GlobalName:
         obj = {}
         obj['pool_name'] = self.pool_name
         obj['ttl'] = self.ttl
+        obj['nsrecord'] = self.nsrecord
 
         return obj
 

--- a/polaris_health/state/pool.py
+++ b/polaris_health/state/pool.py
@@ -344,6 +344,7 @@ class Pool:
         # always build the _default distribution table
         dist_tables['_default'] = {}
         dist_tables['_default']['rotation'] = []
+        dist_tables['_default']['names'] = []
         dist_tables['_default']['num_unique_addrs'] = 0
        
         ##################
@@ -367,6 +368,7 @@ class Pool:
                 # the _default distribution table
                 for i in range(member.weight):
                     dist_tables['_default']['rotation'].append(member.ip)
+                    dist_tables['_default']['names'].append(member.name)
 
                 # increase the number of unique addresses in the _default by 1
                 dist_tables['_default']['num_unique_addrs'] += 1

--- a/polaris_pdns/core/polaris.py
+++ b/polaris_pdns/core/polaris.py
@@ -163,11 +163,11 @@ class Polaris(RemoteBackend):
                              content=dist_table['names'][dist_table['index']],
                              ttl=self._state['globalnames'][qname]['ttl'])
 
-             # increase index
-             dist_table['index'] += 1
-             # set the index to 0 if we reached the end of the rotation list
-             if dist_table['index'] >= len(dist_table['rotation']):
-                 dist_table['index'] = 0
+                # increase index
+                dist_table['index'] += 1
+                # set the index to 0 if we reached the end of the rotation list
+                if dist_table['index'] >= len(dist_table['rotation']):
+                    dist_table['index'] = 0
 
         ### add records to the response ###
         for i in range(num_records_return):

--- a/polaris_pdns/core/polaris.py
+++ b/polaris_pdns/core/polaris.py
@@ -153,6 +153,22 @@ class Polaris(RemoteBackend):
             self.result = False
             return
 
+         ### add NS records to the response if required###
+         if self._state['globalnames'][qname]['nsrecord']:
+             for i in range(num_records_return):
+                 # add record to the response
+                 self.add_record(qtype='NS',
+                             # use the original qname from the parameters dict
+                             qname=params['qname'],
+                             content=dist_table['names'][dist_table['index']],
+                             ttl=self._state['globalnames'][qname]['ttl'])
+
+             # increase index
+             dist_table['index'] += 1
+             # set the index to 0 if we reached the end of the rotation list
+             if dist_table['index'] >= len(dist_table['rotation']):
+                 dist_table['index'] = 0
+
         ### add records to the response ###
         for i in range(num_records_return):
             # add record to the response


### PR DESCRIPTION
We had a need to delegate a subdomain to polaris. This requires the resolver to answer with NS records and glue. I added a new config option called 'nsrecord' which instructs polaris if it should provide a NS response for a particular globalname. If the option is not provided polaris-health will just ignore it. The NS record response comes from a new 'names' dictionary object inside the pools that comes from the name variable in the config, it works just like the rotation dictionary.

Currently the pool that is providing NS records only supports load balancing  via the 'wrr' method as I am only loading the names into the _default dist_table. I don't see any need to do topology load balancing on NS records.
