### PR TITLE
Add IPv6 support in pair to IPv4

### DIFF
--- a/polaris_health/protocols/tcp.py
+++ b/polaris_health/protocols/tcp.py
@@ -34,8 +34,11 @@ class TCPSocket:
         self.auto_timeout = auto_timeout
 
         # create socket
-        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        
+        if ':' in ip:
+            self._sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        else:
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
         self.settimeout(self.timeout)
 
     def connect(self):

--- a/polaris_health/state/pool.py
+++ b/polaris_health/state/pool.py
@@ -240,7 +240,7 @@ class Pool:
             monitor_params = obj['monitor_params']
         else:
             monitor_params = {}
-                 
+
         monitor = monitors.registered[monitor_name](**monitor_params)
 
         ### lb_method
@@ -367,43 +367,27 @@ class Pool:
         dist_tables['_default'] = {}
         dist_tables['_default']['rotation'] = []
         dist_tables['_default']['num_unique_addrs'] = 0
-       
+
+        # do not add members with weight of 0 - member is disabled
+        members = [m for m in self.members if m.weight != 0]
+
         ##################
         ### pool is UP ###
         ##################
         if self.status:
-            for member in self.members:
-                # do not add members with the weight of 0 - member is disabled
-                if member.weight == 0:
-                    continue
+            # do not add members in DOWN state
+            members = [m for m in self.members if m.status]
 
-                # do not add members in DOWN state
-                if not member.status:
-                    continue
+            if self.lb_method == 'twrr':
+                for member in members:
+                    # add the member IP times it's weight into
+                    # the _default distribution table
+                    for i in range(member.weight):
+                        dist_tables['_default']['rotation'].append(member.ip)
 
-                #
-                # add to the _default table
-                #
+                    # increase the number of unique addresses in the _default by 1
+                    dist_tables['_default']['num_unique_addrs'] += 1
 
-                # add the member IP times it's weight into 
-                # the _default distribution table
-                for i in range(member.weight):
-                    dist_tables['_default']['rotation'].append(member.ip)
-
-                # increase the number of unique addresses in the _default by 1
-                dist_tables['_default']['num_unique_addrs'] += 1
-       
-                # if lb_method is failover group do not add any more members
-                if self.lb_method == 'fogroup':
-                    break
-
-                #
-                # add to a regional table
-                #
-
-                # if a topology lb method is used, add the member's IP 
-                # to a corresponding regional table 
-                if self.lb_method == 'twrr':
                     # create the regional table if it does not exist
                     if member.region not in dist_tables:
                         dist_tables[member.region] = {}
@@ -419,15 +403,32 @@ class Pool:
                     # increase the number of unique addresses in the table by 1
                     dist_tables[member.region]['num_unique_addrs'] += 1
 
+            elif self.lb_method == 'fogroup':
+                ip4 = sorted([m for m in members if ':' not in m.ip],
+                        key=lambda k: k.weight, reverse=True)
+                ip6 = sorted([m for m in members if ':' in m.ip],
+                        key=lambda k: k.weight, reverse=True)
+
+                members = []
+                if ip4:
+                    members.append(ip4[0])
+                if ip6:
+                    members.append(ip6[0])
+
+                for member in members:
+                    # add the member IP times it's weight into
+                    # the _default distribution table
+                    for i in range(member.weight):
+                        dist_tables['_default']['rotation'].append(member.ip)
+
+                    # increase the number of unique addresses in the _default by 1
+                    dist_tables['_default']['num_unique_addrs'] += 1
+
         ####################
         ### pool is DOWN ###
         ####################
         else:
-            for member in self.members:
-                # do not add members with weight of 0 - member is disabled
-                if member.weight == 0:
-                    continue
-
+            for member in members:
                 # add to the _default table if fallback is set to 'any'
                 if self.fallback == 'any':
                     # add the member IP times it's weight into
@@ -445,13 +446,13 @@ class Pool:
         for name in dist_tables:
             # randomly shuffle the rotation list
             random.shuffle(dist_tables[name]['rotation']) 
-       
+
             # create index used by ppdns for distribution,
             # set it to a random position, when ppdns is
             # syncing its internal state from shared memory, indexes gets
             # reset, we want to avoid starting from 0 every time
             dist_tables[name]['index'] = \
-                int(random.random() * len(dist_tables[name]['rotation'])) 
+                int(random.random() * len(dist_tables[name]['rotation']))
 
         obj['dist_tables'] = dist_tables
 

--- a/polaris_health/state/pool.py
+++ b/polaris_health/state/pool.py
@@ -59,11 +59,6 @@ class PoolMember:
             LOG.error(log_msg)
             raise Error(log_msg)
 
-        if _ip.version != 4:
-            log_msg = 'only v4 IP addresses are currently supported'
-            LOG.error(log_msg)
-            raise Error(log_msg)
-
         self.ip = ip
 
         ### name
@@ -102,11 +97,6 @@ class PoolMember:
             except ValueError:
                 log_msg = ('"{}" does not appear to be a valid IP address'
                            .format(monitor_ip))
-                LOG.error(log_msg)
-                raise Error(log_msg)
-
-            if _ip.version != 4:
-                log_msg = 'only v4 IP addresses are currently supported'
                 LOG.error(log_msg)
                 raise Error(log_msg)
 

--- a/polaris_health/state/pool.py
+++ b/polaris_health/state/pool.py
@@ -378,7 +378,7 @@ class Pool:
             # do not add members in DOWN state
             members = [m for m in self.members if m.status]
 
-            if self.lb_method == 'twrr':
+            if self.lb_method in ('twrr', 'wrr'):
                 for member in members:
                     # add the member IP times it's weight into
                     # the _default distribution table
@@ -388,20 +388,21 @@ class Pool:
                     # increase the number of unique addresses in the _default by 1
                     dist_tables['_default']['num_unique_addrs'] += 1
 
-                    # create the regional table if it does not exist
-                    if member.region not in dist_tables:
-                        dist_tables[member.region] = {}
-                        dist_tables[member.region]['rotation'] = []
-                        dist_tables[member.region]['num_unique_addrs'] = 0
+                    if self.lb_method == 'twrr':
+                        # create the regional table if it does not exist
+                        if member.region not in dist_tables:
+                            dist_tables[member.region] = {}
+                            dist_tables[member.region]['rotation'] = []
+                            dist_tables[member.region]['num_unique_addrs'] = 0
 
-                    # add the member IP times it's weight
-                    # into the regional table
-                    for i in range(member.weight):
-                        dist_tables[member.region]['rotation'].append(
-                            member.ip)
+                        # add the member IP times it's weight
+                        # into the regional table
+                        for i in range(member.weight):
+                            dist_tables[member.region]['rotation'].append(
+                                member.ip)
 
-                    # increase the number of unique addresses in the table by 1
-                    dist_tables[member.region]['num_unique_addrs'] += 1
+                        # increase the number of unique addresses in the table by 1
+                        dist_tables[member.region]['num_unique_addrs'] += 1
 
             elif self.lb_method == 'fogroup':
                 ip4 = sorted([m for m in members if ':' not in m.ip],

--- a/polaris_pdns/config/__init__.py
+++ b/polaris_pdns/config/__init__.py
@@ -13,7 +13,7 @@ BASE = {
 
     'SHARED_MEM_HOSTNAME': '127.0.0.1',
     'SHARED_MEM_STATE_TIMESTAMP_KEY': 'polaris_health:state_timestamp',
-    'SHARED_MEM_PPDNS_STATE_KEY': 'polaris_health:ppdns_state',    
+    'SHARED_MEM_PPDNS_STATE_KEY': 'polaris_health:ppdns_state',
     'SHARED_MEM_SOCKET_TIMEOUT': 1,
 
     'LOG': False,

--- a/polaris_pdns/core/polaris.py
+++ b/polaris_pdns/core/polaris.py
@@ -119,7 +119,7 @@ class Polaris(RemoteBackend):
                 return
 
             # ANY/A response
-            if params['qtype'] == 'ANY' or params['qtype'] == 'A':
+            if params['qtype'] in ('ANY', 'A', 'AAAA'):
                 self._any_response(params)
                 return
 
@@ -148,7 +148,7 @@ class Polaris(RemoteBackend):
         # get a pool associated with the qname
         pool_name = STATE['globalnames'][qname]['pool_name']
         pool = STATE['pools'][pool_name]
-       
+
         # use the _default distribution table by default
         dist_table = pool['dist_tables']['_default']
 
@@ -196,12 +196,43 @@ class Polaris(RemoteBackend):
         self.log.append('dist table used: {}'
                         .format(json.dumps(dist_table)))
 
+
+        responses=[]
+        ### add records to the response ###
+        for i in range(len(dist_table['rotation']):
+            if ':' in dist_table['rotation'][dist_table['index']]:
+                qtype='AAAA'
+            else:
+                qtype='A'
+            # add record to the responses
+            responses.append(
+                {'qtype': qtype,
+                # use the original qname from the parameters dict
+                'qname': params['qname'],
+                'content': dist_table['rotation'][dist_table['index']],
+                'ttl': STATE['globalnames'][qname]['ttl']
+                })
+
+            # increase index
+            dist_table['index'] += 1
+            # set the index to 0 if we reached the end of the rotation list
+            if dist_table['index'] >= len(dist_table['rotation']):
+                dist_table['index'] = 0
+
+        # TODO: remove dublicates from responses
+
+        # sort records by type
+        if params['qtype'] == 'A':
+            responses = [r for r in responses if r['qtype'] == 'A']
+        elif params['qtype'] == 'AAAA':
+            responses = [r for r in responses if r['qtype'] == 'AAAA']
+
         # determine how many records to return
         # which is the minimum of the dist table's num_unique_addrs and 
         # the pool's max_addrs_returned
-        if dist_table['num_unique_addrs'] <= pool['max_addrs_returned']: 
-            num_records_return = dist_table['num_unique_addrs']
-        else:    
+        if len(responses) <= pool['max_addrs_returned']:
+            num_records_return = len(responses)
+        else:
             num_records_return = pool['max_addrs_returned']
 
         # if we don't have anything to return(all member weights may have
@@ -210,20 +241,8 @@ class Polaris(RemoteBackend):
             self.result = False
             return
 
-        ### add records to the response ###
-        for i in range(num_records_return):
-            # add record to the response
-            self.add_record(qtype='A',
-                            # use the original qname from the parameters dict        
-                            qname=params['qname'],
-                            content=dist_table['rotation'][dist_table['index']],
-                            ttl=STATE['globalnames'][qname]['ttl'])    
-
-            # increase index
-            dist_table['index'] += 1
-            # set the index to 0 if we reached the end of the rotation list
-            if dist_table['index'] >= len(dist_table['rotation']):
-                dist_table['index'] = 0
+        for r in responses[:num_records_return]:
+            self.add_record(**r)
 
     def _soa_response(self, params):
         """Generate a response to a SOA query."""

--- a/polaris_pdns/core/polaris.py
+++ b/polaris_pdns/core/polaris.py
@@ -199,7 +199,7 @@ class Polaris(RemoteBackend):
 
         responses=[]
         ### add records to the response ###
-        for i in range(len(dist_table['rotation']):
+        for i in range(len(dist_table['rotation'])):
             if ':' in dist_table['rotation'][dist_table['index']]:
                 qtype='AAAA'
             else:

--- a/polaris_pdns/core/remotebackend.py
+++ b/polaris_pdns/core/remotebackend.py
@@ -15,11 +15,11 @@ class RemoteBackend:
 
     """PowerDNS Remote Backend handler 
 
-    Implements pipe handler for PowerDNS Remote Backend JSON API:      
+    Implements pipe handler for PowerDNS Remote Backend JSON API:
     https://doc.powerdns.com/md/authoritative/backend-remote/
 
     Child classes must implement self.do_<something>(params)
-    methods for JSON API calls they need to handle, where <something> 
+    methods for JSON API calls they need to handle, where <something>
     must match an exact JSON API method name.
     """
 


### PR DESCRIPTION
Processing IPv6 addresses at the same manner, as IPv4. There is no changes in config structure.
'fogroup' LB method will return one IPv4 and one IPv6 (if this IPs would be available of course) with maximum weight.
Pdns Polaris class now can proceed AAAA dns responses, and ANY type would return both A and AAAA.